### PR TITLE
Fix sesion.resolveProxy call for Electron Shell 7+

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var debug = require('debug')('electron-proxy-agent');
  * session : {
  *   resolveProxy(url, callback)
  * }
- * 
+ *
  * See https://github.com/atom/electron/blob/master/docs/api/session.md#sesresolveproxyurl-callback
  *
  * @api public
@@ -99,10 +99,16 @@ function connect (req, opts, fn) {
   }));
 
   debug('url: %o', url);
-  self.session.resolveProxy(url, onproxy);
+  var handled = false;
+  var promise = self.session.resolveProxy(url, onproxy);
+  if(promise && promise.then) {
+    promise.then(onproxy);
+  }
 
   // `resolveProxy()` callback function
   function onproxy (proxy) {
+    if(handled) return;
+    handled = true
 
     // default to "DIRECT" if a falsey value was returned (or nothing)
     if (!proxy) proxy = 'DIRECT';


### PR DESCRIPTION
The resolveProxy() call with the callback was deprecated in Electron Shell 6 and removed in Electron Shell 7. 

So in Electron Shell 7 this module stopped working as only the promise version is present. 

I tried to fix it in a way that works on the old versions as well as ES6, that has both the callback and returns a promise, and ES7+ that ignores the callback.

See:
https://github.com/electron/electron/blob/6-0-x/docs/api/session.md#sesresolveproxyurl-callback
https://github.com/electron/electron/blob/6-0-x/docs/api/session.md#sesresolveproxyurl
https://github.com/electron/electron/blob/7-0-x/docs/api/session.md#sesresolveproxyurl